### PR TITLE
chore(ci): stop uploading the redundant results-zip artifact

### DIFF
--- a/.github/workflows/daily_run.yml
+++ b/.github/workflows/daily_run.yml
@@ -33,9 +33,3 @@ jobs:
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Upload artifact
-      uses: actions/upload-artifact@main
-      with:
-        name: results-zip
-        path: results/*.zip


### PR DESCRIPTION
## Summary
`daily_run.yml` uploads `results/*.zip` as a `results-zip` artifact on every run (2×/day), which has accumulated **828 artifacts**. The data those zips contain is **already committed to git** by the workflow's "Commit and push changes" step — so the artifact is redundant.

## Change
Remove the trailing **Upload artifact** step. The data pipeline is unchanged: the workflow still runs `get_zipped.sh` and commits the refreshed data.

## Why
Trims Actions artifact-storage churn (one input to the account-wide artifact-quota pressure that's currently blocking other repos' releases). Small contributor (~0.06 GiB) but pure hygiene.

## No data loss
The canonical data and history live in git and are unaffected:
- `data/output.json`, `data/output.csv` — committed each run
- `data/history/prices.json` — committed history
- full 2×/day time-series preserved in the commit log
- `results/` is **gitignored**; the zips only duplicated already-committed data.

## Acceptance
- [ ] Workflow still fetches + commits data on schedule
- [ ] No `results-zip` artifact produced
- [ ] Live site (openrouterlist.jvrck.com) unaffected